### PR TITLE
Adds securedrop-workstation-dom0-config 0.2.0

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.0-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.0-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a4202722c318f628c2b980da847008a9f5e7bea9101ffe4c6eb790a0ad221fb
+oid sha256:3fd3e83244e88e4e4e2f35a7109ceb9c32d3490ea15196279d7fb5114a9b73fb
 size 97658

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.0-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.0-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a4202722c318f628c2b980da847008a9f5e7bea9101ffe4c6eb790a0ad221fb
+size 97658


### PR DESCRIPTION
This is the final piece that will allow us to test production flows for the workstation. Build logs are available in https://github.com/freedomofpress/build-logs/commit/b2af83d527bc531d14292715d0763ba3d981276e
### Test Plan
- In securedrop-workstation repo:
    - [x] `git tag -v 0.2.0` the tag is properly signed
    - [x] Build logs, including artifact integrity are verified
    - [x] CI is passing - the RPM is properly signed
