### PR TITLE
securedrop-workstation-dom0-config 0.2.1

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.1-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe2e14b15392f3e485d9f5940bab48cfd13110a1117eb5cdfc4c3ca77bd02709
+size 100094

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.1-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe2e14b15392f3e485d9f5940bab48cfd13110a1117eb5cdfc4c3ca77bd02709
+oid sha256:1629334229bfe3478c5e14bea9b512d7508608430e5a32907c06a374d58e7ab0
 size 100094


### PR DESCRIPTION
Adds provisioning fixes discovered during the first release: https://github.com/freedomofpress/securedrop-workstation/pull/468
Build logs available here: https://github.com/freedomofpress/build-logs/commit/f38a8b6b9723da56ffe976f40bde2d654e7c6246

### Test Plan
- In securedrop-workstation repo:
    - [x] `git tag -v 0.2.1` the tag is properly signed
    - [x] Build logs, including artifact integrity are verified
    - [x] CI is passing - the RPM is properly signed
    - [x] `rpm --delsign` returns to the original rpm version, with checksum in build logs