### PR TITLE
securedrop-workstation-dom0-config 0.2.2

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.2-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.2-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a530acbf0e5d2b1189087818ffd26e3032a01e46aa82637e665733d150c635bb
+oid sha256:20c38932dea7090b5f860cf547d05fffa53b7feb43db63735b7061f60cf5f368
 size 100946

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.2-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.2-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a530acbf0e5d2b1189087818ffd26e3032a01e46aa82637e665733d150c635bb
+size 100946


### PR DESCRIPTION
Build logs: https://github.com/freedomofpress/build-logs/commit/36ac40a24345310cca57f6598dc3e96e8e88a12f


### Test Plan
- In securedrop-workstation repo:
    - [ ] `git tag -v 0.2.2` the tag is properly signed
    - [ ] Build logs, including artifact integrity are verified
    - [ ] CI is passing - the RPM is properly signed
    - [ ] `rpm --delsign` returns to the original rpm version, with checksum in build logs linked above