### PR TITLE
Release securedrop-workstation-dom0-config 0.2.3

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.3-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.3-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:778f8c0e867dd2e93cdd9f4cb1cefe06a6fe2ac2df3f9b1e6938f7a83694ce6a
+oid sha256:38838da945df68c68d60763093300d81925eb88e268ab008561f6ff2162ef9b8
 size 102958

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.3-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.2.3-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:778f8c0e867dd2e93cdd9f4cb1cefe06a6fe2ac2df3f9b1e6938f7a83694ce6a
+size 102958


### PR DESCRIPTION
Build logs: https://github.com/freedomofpress/build-logs/commit/b45d628057255d9ea828c71afe3768131c25a906
### Test Plan
- In securedrop-workstation repo:
    - [ ] `git tag -v 0.2.3` the tag is properly signed
    - [ ] Build logs, including artifact integrity are verified
    - [ ] CI is passing - the RPM is properly signed
    - [ ] `rpm --delsign` returns to the original rpm version, with checksum in build logs linked above