### PR TITLE
Release Securedrop Workstation dom0 0.3.0 config RPM

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68e8ebd2e132059d2c080e69b753b0d540b6c57e5004e290aa341d5a78585f80
+oid sha256:0c0e0a425f49bd4b5a457d6cc4f667181b63d44f1e852dc132ca2326dabfd03c
 size 107674

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68e8ebd2e132059d2c080e69b753b0d540b6c57e5004e290aa341d5a78585f80
+size 107674


### PR DESCRIPTION
Build logs: https://github.com/freedomofpress/build-logs/commit/5c99f38366db27840546109beb9150ce557aa92e

### Test Plan
- [ ] In securedrop-workstation repo: `git tag -v 0.3.0` the tag is signed with prod release key and points to the right commit
- [ ] Build logs, including artifact integrity are verified
- [ ] CI is passing - the RPM is properly signed
- [ ] `rpm --delsign` returns to the original rpm version, with checksum in build logs linked above