### PR TITLE
securedrop-workstation-dom0-config 0.3.1

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.1-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:908d4e2405ab447cdcb8316463b1d1a93fa8ac1d280fb81d898ba6f59759a550
+size 104850

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.1-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:908d4e2405ab447cdcb8316463b1d1a93fa8ac1d280fb81d898ba6f59759a550
+oid sha256:a7ee4b78817be6ac7ca902a71e4ea56ce43b03aa0b4d5ba32e3e68d65b2d83c8
 size 104850


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.3.1 
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/4e450b0f3b7013ca05d994a5b86fd2982ddcef79
- [x] CI is passing, the rpm is properly signed with the prod key
- [x] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs