### PR TITLE
Adds PR template for prod LFS packages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+###
+Name of package:
+
+
+### Test plan
+
+- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/x.y.z
+- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/1234
+- [ ] CI is passing, the rpm is properly signed with the prod key
+- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs


### PR DESCRIPTION
Matches changes presented in the dev RPM repo [0],
porting here to reduce the copy/paste workflow when adding packages.

[0] https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/12