### PR TITLE
Add securedrop-workstation-dom0-config 0.4.0

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.4.0-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.4.0-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7040f96768418da64d14c2f1cdac241dcb67488da37272f9338a052835309c96
+oid sha256:f3f579344718c7dde09bacd3d4fe643769e40dba82139539fd27a602dfc715da
 size 104498

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.4.0-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.4.0-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7040f96768418da64d14c2f1cdac241dcb67488da37272f9338a052835309c96
+size 104498


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.4.0
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/4911299509b028a2d3b14dbe9dae487960442c51
- [x] CI is passing, the rpm is properly signed with the prod key
- [x] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
