### PR TITLE
Promotes Workstation TemplateVM RPM to prod

### DIFF
--- a/workstation/dom0/f25/qubes-template-securedrop-workstation-buster-4.0.1-202007062239.noarch.rpm
+++ b/workstation/dom0/f25/qubes-template-securedrop-workstation-buster-4.0.1-202007062239.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:683d967545b06bc92e75d7ee57b1372046ac09278c89f1806706224e19e92c62
+size 866727688


### PR DESCRIPTION


###
Name of package: `qubes-template-securedrop-workstation-buster`

This is version 202007062239 of the SDW template, which bundles the 'securedrop-keyring' package at build time. The RPM is the same artifact originally submitted in https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/15

### Test plan

- [x] CI is passing, the rpm is properly signed with the prod key
- [x] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs for https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/15
