### PR TITLE
Release securedrop-workstation-dom0-config 0.5.0

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.0-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.0-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8fa7b1e665b580fcf2dc0cbeeb67915d0a03656988b37f494ccd83324a40129
+size 107690


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-workstation/issues/624

### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.0
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/4edbbdb0ddaa2c76764655b66286f255e119b356
- [ ] CI is passing, the rpm is properly signed with the prod key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
