### PR TITLE
Adds securedrop-workstation-dom0-config 0.5.1

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.1-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:234615b2421dd3f9238015d6a167c461a2079bc42d28935b8a4da0a0066bc6ff
+size 107818


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.1 
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/6fb6ad046f30ccbbcf8ca9b853e57afe68527ac0
- [x] CI is passing, the rpm is properly signed with the prod key
- [x] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
