### PR TITLE
Adds securedrop-workstation-dom0-config 0.5.3

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.3-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.3-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7a42de13d27a3769162918a4206b9f4844ed8eb2ac2c799323e6fb39e62adaf
+size 108410

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.3-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.3-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7a42de13d27a3769162918a4206b9f4844ed8eb2ac2c799323e6fb39e62adaf
+oid sha256:0d23b02390e9eda95708d7fd5e5e1a08701a6d41ad0b715980f626a207aa505e
 size 108410


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`

This is the same artifact presented in https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/22, resigned with prod key for promotion to prod.

### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.3
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/dd5048671b027922fc0e283479bdf21b2ffcceb7
- [x] CI is passing, the rpm is properly signed with the prod key
- [x] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
