### PR TITLE
Add sdw-dom0-config 0.5.4 RPM

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.4-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.4-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb94f32ebffe8cb5e094a3fe701661456f20a8338435231e129abda381c90a25
+size 123092


### PR DESCRIPTION


###
Name of package: `securedrop-workstation-dom0-config`

Signed with the current release key, i.e.
22245C81E3BAEB4138B36061310F561200F4AD77,
which is set to expire on 2021-06-30.
We'll follow up with a subsequent release
to finalize the key rotation.

### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.4
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/60e5089a34269bf8dcb69701bbc8e6402cad6aae
- [ ] CI is passing, the rpm is properly signed with the prod key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
