### PR TITLE
Adds sdw-config 0.5.5 rpm

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.5-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.5-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c81399f7a05f4f7b5955843774e2e6e61b0df051a835043c70cbb461eab69c32
+size 123235


### PR DESCRIPTION

###
Name of package: `securedrop-workstation-dom0-config`

Includes changes from:

  * https://github.com/freedomofpress/securedrop-workstation/pull/707
  * https://github.com/freedomofpress/securedrop-workstation/pull/708

Signed with the old/current key, i.e.
22245C81E3BAEB4138B36061310F561200F4AD77

### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.5
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/da7964dc621dd8abadf4e0084c329c38d7b96438
- [ ] CI is passing, the rpm is properly signed with the prod key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
