### PR TITLE
Resigns sdw-dom0-config 0.5.5 with new key

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.5-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.5-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c81399f7a05f4f7b5955843774e2e6e61b0df051a835043c70cbb461eab69c32
+oid sha256:5db66ad8f3f927a2fcf3d6c9dd5cfea7fb05cb5d748a7d18e02a75b5f35af078
 size 123235


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`


As part of the 2021 key rotation, we'll simply re-sign the existing RPM
for v0.5.5 with the new key, to simplify the first run story.
In the near future, we'll release a new version and make sure that's
signed, but until that's done, we can still ensure that the prod repo's
most recent versions are all properly signed with the new key.

Refs https://github.com/freedomofpress/securedrop-workstation/issues/714#issuecomment-892829531

### Test plan

- [x] Run `rpm -Kv <rpm>` on this new artifact, and confirm that the `keyid` matches that of the new 2021 release key (e.g. `qubes-gpg-client -k <keyid>` to inspect fingerprint and uid)
- [x] Run `rpm --delsign <rpm>` on this new artifact, and confirm that the checksum matches what was in the original build logs: https://github.com/freedomofpress/build-logs/commit/da7964dc621dd8abadf4e0084c329c38d7b96438 
- [x] CI is passing, the rpm is properly signed with the prod key
