### PR TITLE
Tweak PR docs for rpm delsign invocations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,4 @@ Name of package:
 - [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/x.y.z
 - [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/1234
 - [ ] CI is passing, the rpm is properly signed with the prod key
-- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
+- [ ] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs


### PR DESCRIPTION
Updates the PR template with more informative docs.

Require use of Debian Stable. Technically I've only tested with
Buster, which has 4.14.2.1+dfsg1-1 at time of writing. Perhaps Bullseye
will break things for us. For certain, the `rpm` in recent versions of
Fedora doesn't revert to the original checksum when running delsign.
Haven't investigated why.