### PR TITLE
Adds sdw-config 0.5.6 rpm

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.6-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.6-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbba76d96c5667dd0d8ed4a8f08edd33127210d6f3d82debaad6444b2fd654fe
+size 123026


### PR DESCRIPTION

###
Name of package: `securedrop-workstation-dom0-config`, v0.5.6


### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.6
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/c8369ee3d94d1f9ac58e63e7a3df5e5c7420274e
- [ ] CI is passing, the rpm is properly signed with the prod key
- [ ] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs
