### PR TITLE
Adds sdw-config 0.5.7 rpm

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.7-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.7-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5eb54d073e1e42d6b6ffc1d68f5b8d09d1cd90c95e621206f300c1d63c6fc56
+size 123109


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`

Same RPM as submitted in https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/pull/23 , but resigned with the prod key. 

Towards https://github.com/freedomofpress/securedrop-workstation/issues/737

### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.7
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/5b9ec0d1cac962b0de06d069410cf3ff72a9c5c0
- [x] CI is passing, the rpm is properly signed with the prod key
- [x] RPM is signed specifically with 2359E6538C0613E652955E6C188EDD3B7B22E6A3, i.e. the "new" 2021 key
- [x] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs
