### PR TITLE
add sdw-config 0.6.0 rpm

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.0-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.0-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36abf94d6dada0e2cb1f439bb71e7c7b71eeb05d78acb08e6de1662fb7087bcb
+size 127668


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`

Adds the same RPM as submitted in https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/pull/23, but resigned with the prod key. 

Closes https://github.com/freedomofpress/securedrop-workstation/issues/760

### Test plan

The RPM has already been checked via https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/30, so the rest of the checks are around it being signed with the prod key.

- [ ] CI is passing therefore the RPM is properly signed with the prod key
- [ ] RPM is signed specifically with the `2359E6538C0613E652955E6C188EDD3B7B22E6A3` key
- [ ] Unsigned RPM, after running `rpm --delsign` (in Debian Stable), on the signed RPM results in the checksum found in the build logs linked to in https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/30