### PR TITLE
Use debian:buster CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,13 @@ version: 2.1
 jobs:
   tests:
     docker:
-      - image: circleci/python:3.7-buster
+      - image: debian:buster
     steps:
+      - run: apt-get update && apt-get install -y sudo
       - run:
           name: Install Debian packaging dependencies
           command: |
-            sudo apt install rpm git-lfs
+            sudo apt install -y python3 git rpm git-lfs
 
       - run:
           name: Clone the repository with LFS


### PR DESCRIPTION

CI was failing; this change implements the same update as

https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/31

Verify that CI is passing; that's enough for merge. 
