### PR TITLE
Release securedrop workstation dom0 config 0.6.1

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e303c4e8fc2e8b89a7b4d129a5974d7b2a7dc9706fdcf181861735624423cc05
+size 127767

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e303c4e8fc2e8b89a7b4d129a5974d7b2a7dc9706fdcf181861735624423cc05
+oid sha256:d894919eae6157e8ff6d76955d7bb8eec855a8394053c53c36148c6193ae0d4f
 size 127767


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`, version 0.6.1

Note that I added the unsigned RPM as a separate commit for the record.

### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.6.1 (should point to the 0.6.1-rc1 -> 0.6.1 changelog commit: https://github.com/freedomofpress/securedrop-workstation/commit/73df5c0b3cc200dd5c0b6ac266f658fc4ccb8034)
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/75c729255035fc9854264db70f98bd61ce56002d
- [ ] CI is passing (which means the rpm is properly signed with the prod key)
- [ ] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs
