### PR TITLE
Release securedrop workstation dom0 config 0.6.1

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e47ecabb8a73b032e00464a6b35c21fc4a334e5c450a55c4872c08b35dedcc5
+size 127767

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e47ecabb8a73b032e00464a6b35c21fc4a334e5c450a55c4872c08b35dedcc5
+oid sha256:766ef7791812b3c21311d201ad6b477f02cf47641073cb0c4c7237b60e6a0092
 size 127767


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`, version 0.6.1

Note that I added the unsigned RPM as a separate commit for the record.

### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.6.1 (should point to the 0.6.1-rc1 -> 0.6.1 changelog commit: https://github.com/freedomofpress/securedrop-workstation/commit/e319486326925b71adeec8a1762681d1e681a589)
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/c22d8a789306aa801492912c867d48a4f6e448a9
- [ ] CI is passing (which means the rpm is properly signed with the prod key)
- [ ] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs
