### PR TITLE
Revert "add securedrop-workstation-dom0-config 0.6.1 signed package"

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:766ef7791812b3c21311d201ad6b477f02cf47641073cb0c4c7237b60e6a0092
+oid sha256:2e47ecabb8a73b032e00464a6b35c21fc4a334e5c450a55c4872c08b35dedcc5
 size 127767

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e47ecabb8a73b032e00464a6b35c21fc4a334e5c450a55c4872c08b35dedcc5
-size 127767


### PR DESCRIPTION
The CI build of #28 was legitimately failing because the RPM package signature was incorrect. (The wrong key was used.)

This reverts commit e929a38e6512b108f34c878b6debe5bbcd2839a4.
See https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/pull/28
