### PR TITLE
Re-release securedrop workstation dom0 config 0.6.1

### DIFF
--- a/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
+++ b/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48605ee71caa21d238d9716b66db39cd45e3311cd105ce228995642324567c1f
+size 127767

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e47ecabb8a73b032e00464a6b35c21fc4a334e5c450a55c4872c08b35dedcc5
+size 127767

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e47ecabb8a73b032e00464a6b35c21fc4a334e5c450a55c4872c08b35dedcc5
+oid sha256:20d642bbe6a66538d8a8f192e3eda99acdcd7adb70a9d824de3d9d8bc81e5a16
 size 127767


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`, version 0.6.1

Note that I added the unsigned RPM as a separate commit for the record.

:warning: This is in draft mode until CI checks are fixed for this repo. Also, notice the additional check to manually verify that the rpm is properly signed with the prod key below.

### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.6.1 (should point to the 0.6.1-rc1 -> 0.6.1 changelog commit: https://github.com/freedomofpress/securedrop-workstation/commit/e319486326925b71adeec8a1762681d1e681a589)
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/c22d8a789306aa801492912c867d48a4f6e448a9
- [ ] CI is passing (which means the rpm is properly signed with the prod key)
- [ ] Manually verify that the rpm is properly signed with the prod key by running `rpm -qi <rpm>` and copy pasting the Signature KEY ID into `gpg -k <KEY ID>` 
- [ ] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs
