### PR TITLE
Release securedrop-workstation-dom0-config 0.6.2 to yum prod

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.2-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.2-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbe6e91c471a750b538b11d418982f75045c3fc06410e7896ba1e7deeb1e2544
+size 127865


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config 0.6.2`

Same artifact from https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/33 was resigned with the prod signing key.

### Test plan

  - [x] Tag in securedrop-workstation repository is correct: (see https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/33)
  - [x] Build logs are included: (see https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/33)
  - [ ] CI is passing, the rpm is properly signed with the prod key
  - [ ] Unsigned RPM after running `rpm --delsign` (in Debian ~Stable~ Buster) on the signed RPM results in the checksum found in the build logs

In addition:
- [ ] Manually verify that the rpm is properly signed with the PROD key by running `rpm -qi <rpm>` and copy pasting the Signature KEY ID into `gpg -k <KEY ID>` 
