### PR TITLE
Resign and promote qubes-template-securedrop-workstation (build tag:…

### DIFF
--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eb8b2447baaa495b961ad9a189e30c9bc267e1e0d00b299958702950ebdd645
+size 894939705


### PR DESCRIPTION
## Description

Promoting [package on yum-test ](https://yum-test.securedrop.org/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm) to prod (see https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/37).

Package being released: `qubes-template-securedrop-workstation`
Package tag: https://github.com/freedomofpress/qubes-template-securedrop-workstation/releases/tag/0.3.0
Build logs: https://github.com/freedomofpress/build-logs/commit/ed07a59e31d4ae56c341518b5dd0facc617d20dc
Prod signing key used to sign package and tag: https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/blob/HEAD/pubkeys/prod.key

Release tracking issue: https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/issues/33

## Checklist for PR owner

- [x] Links in this PR template have been updated as required
- [x] https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/blob/HEAD/pubkeys/prod.key points to the correct prod signing key

## Checklist for reviewer
- [ ] CI is passing
- [ ] The RPM is signed with the prod signing key
    > * Download the signed RPM from this PR
    > * Run `rpm -qi <signed-rpm>` to get the KEY ID
    > * Run `gpg -k <KEY ID>` to verify that it matches the prod signing key (make sure you have the prod signing key referenced in the PR description in your GPG keyring)
- [ ] The Unsigned RPM checksum matches what's in the build logs
    > * Download the signed RPM from this PR (if you haven't already)
    > * Run `rpm --delsign <signed-rpm>` to remove the signature (do this on fedora 33 or 34, see last line in build logs for rpm version)
    > * Run `sha256sum <unsigned-rpm>` and compare