### PR TITLE
promote securedrop-workstation-dom0-config 0.7.0 to prod

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.0-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.0-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:274a5540373397a791008d3b1dc02071ea87231c6c0824481597c38c45596ffe
+size 127731


### PR DESCRIPTION
## Description

Promoting [package on yum-test ](https://yum-test.securedrop.org/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.0-1.fc32.noarch.rpm) to prod (see https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/38).

Package being released: `securedrop-workstation-dom0-config 0.7.0`
Package tag: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.7.0
Build logs: (see https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/38)
Prod signing key used to sign package and tag: https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/blob/HEAD/pubkeys/prod.key

Release tracking issue: https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/issues/33

## Checklist for PR owner

- [x] Links in this PR template have been updated as required
- [x] https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/blob/HEAD/pubkeys/prod.key points to the correct prod signing key

## Checklist for reviewer
- [ ] CI is passing
- [ ] The RPM is signed with the prod signing key
    > * Download the signed RPM from this PR
    > * Run `rpm -qi <signed-rpm>` to get the KEY ID
    > * Run `gpg -k <KEY ID>` to verify that it matches the prod signing key (make sure you have the prod signing key referenced in the PR description in your GPG keyring)
- [ ] The Unsigned RPM checksum matches what's in the build logs (follow steps below on Debian Buster)
    > * Download the signed RPM from this PR (if you haven't already)
    > * Run `rpm --delsign <signed-rpm>` to remove the signature
    > * Run `sha256sum <unsigned-rpm>` and compare